### PR TITLE
Add initial stack configs, scripts, and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+ADMIN_TOKEN=________32RANDOM________
+POSTGRES_PASSWORD=changeMeStrong
+ROLE=PRIMARY

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+**/data
+node_modules
+vendor
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # infra-stacks
+
+High-Availability Docker stacks for two Synology NAS systems. The stacks include Vaultwarden, Authentik, a placeholder SSO service and Cloudflare Tunnel. The ROLE variable allows running either as PRIMARY or BACKUP node.
+
+```mermaid
+sequenceDiagram
+    browser->>cloudflare: HTTPS Request
+    cloudflare->>NASA: Tunnel
+    cloudflare->>NASB: Tunnel
+    NASA->>Docker: App
+    NASB->>Docker: App
+```
+
+## Quick Start
+1. `git clone <repo>`
+2. `cp .env.example .env`
+3. Upload compose files via Portainer and deploy.
+
+## Failover Testing
+Stop `cloudflared` on the primary NAS and run `scripts/promote_backup.sh <primary-ip>` on the backup to switch roles.

--- a/authentik.yaml
+++ b/authentik.yaml
@@ -1,0 +1,36 @@
+version: "3.9"
+services:
+  authentik:
+    image: ghcr.io/goauthentik/server:2025.6.0
+    restart: unless-stopped
+    environment:
+      - ROLE=${ROLE:-PRIMARY}
+      - AUTHENTIK_SECRET_KEY=${AUTHENTIK_SECRET_KEY}
+      - DATABASE_URL=postgresql://authentik:${POSTGRES_PASSWORD}@db/authentik
+    volumes:
+      - authentik-data:/data
+    command: >
+      /bin/sh -c 'if [ "$ROLE" = "PRIMARY" ]; then /entrypoint.sh; else tail -f /dev/null; fi'
+    depends_on:
+      - db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=authentik
+    volumes:
+      - authentik-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+volumes:
+  authentik-data:
+  authentik-postgres-data:

--- a/cloudflared.yaml
+++ b/cloudflared.yaml
@@ -1,0 +1,17 @@
+version: "3.9"
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:2025.6.0
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - /etc/cloudflared:/etc/cloudflared:ro
+    environment:
+      - ROLE=${ROLE:-PRIMARY}
+    command: >
+      /bin/sh -c 'if [ "$ROLE" = "PRIMARY" ]; then cloudflared tunnel run; else tail -f /dev/null; fi'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:2000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5

--- a/psso.yaml
+++ b/psso.yaml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  psso:
+    image: hello-world
+    restart: unless-stopped
+    environment:
+      - ROLE=${ROLE:-PRIMARY}
+    command: >
+      /bin/sh -c 'if [ "$ROLE" = "PRIMARY" ]; then echo running psso; else tail -f /dev/null; fi'
+    volumes:
+      - psso-data:/data
+    healthcheck:
+      test: ["CMD", "echo", "ok"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+volumes:
+  psso-data:

--- a/scripts/db_dumps.sh
+++ b/scripts/db_dumps.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Cron example for DSM: 0 2 * * * /path/to/db_dumps.sh
+mkdir -p ./data/db-dumps
+pg_dumpall > ./data/db-dumps/$(date +%F).sql

--- a/scripts/promote_backup.sh
+++ b/scripts/promote_backup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Usage: promote_backup.sh <PRIMARY_IP>
+PRIMARY_IP="$1"
+if ! ping -c1 "$PRIMARY_IP" >/dev/null 2>&1; then
+  export ROLE=PRIMARY
+  docker compose -f vaultwarden.yaml -f authentik.yaml -f psso.yaml -f cloudflared.yaml up -d
+fi

--- a/vaultwarden.yaml
+++ b/vaultwarden.yaml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  vaultwarden:
+    image: vaultwarden/server:1.30.5
+    restart: unless-stopped
+    environment:
+      - ADMIN_TOKEN=${ADMIN_TOKEN}
+      - ROLE=${ROLE:-PRIMARY}
+    volumes:
+      - vaultwarden-data:/data
+    command: >
+      /bin/sh -c 'if [ "$ROLE" = "PRIMARY" ]; then /usr/bin/dumb-init /start.sh; else tail -f /dev/null; fi'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+volumes:
+  vaultwarden-data:


### PR DESCRIPTION
## Summary
- provide compose stacks for Vaultwarden, Authentik, placeholder PSSO, and Cloudflared
- add helper scripts for backup promotion and DB dumps
- document project with README, MIT license, and environment example

## Testing
- `git status --short`
- `git log --reverse --oneline`


------
https://chatgpt.com/codex/tasks/task_e_685b8ccc09d4832681db83cde09f4993